### PR TITLE
Image Fixes

### DIFF
--- a/src/main/java/com/hollandjake/messengerBotAPI/message/Image.java
+++ b/src/main/java/com/hollandjake/messengerBotAPI/message/Image.java
@@ -41,7 +41,7 @@ public class Image extends MessageComponent implements Transferable {
 
 	public InputStream toStream() {
 		try {
-			new ByteArrayInputStream(toByteArrayOutputStream(image).toByteArray());
+			return new ByteArrayInputStream(toByteArrayOutputStream(image).toByteArray());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
Images were being stored incorrectly due to the size of the image being loaded incorrectly.